### PR TITLE
Fix deprecation warning in Ruby 2.4 and later about Fixnum

### DIFF
--- a/lib/thin_out_backups.rb
+++ b/lib/thin_out_backups.rb
@@ -61,7 +61,7 @@ class ThinOutBackups::Command
       @parent = parent
       @name = name
       (
-      raise "Invalid quota '#{quota}'" unless quota.is_a?(Fixnum) || quota =~ @@quota_format
+      raise "Invalid quota '#{quota}'" unless quota.is_a?(Integer) || quota =~ @@quota_format
       @quota = quota
       )
       @keepers = []


### PR DESCRIPTION
Getting this deprecation warning:

```
/home/app/.gem/ruby/2.4.5/gems/thin_out_backups-0.0.6/lib/thin_out_backups.rb:64: warning: constant ::Fixnum is deprecated
```
