### PR TITLE
Remove reference to Fixnum and replace with Integer

### DIFF
--- a/lib/thin_out_backups.rb
+++ b/lib/thin_out_backups.rb
@@ -61,7 +61,7 @@ class ThinOutBackups::Command
       @parent = parent
       @name = name
       (
-      raise "Invalid quota '#{quota}'" unless quota.is_a?(Fixnum) || quota =~ @@quota_format
+      raise "Invalid quota '#{quota}'" unless quota.is_a?(Integer) || quota =~ @@quota_format
       @quota = quota
       )
       @keepers = []
@@ -117,7 +117,7 @@ class ThinOutBackups::Command
       end
     end
 
-    def keep_all?; quota =~ /\*/ end
+    def keep_all?; quota.to_s =~ /\*/ end
     
     def satisfied?
       if keep_all?


### PR DESCRIPTION
Getting this error with the latest Ruby 3:

```
/home/jash/.rvm/gems/ruby-3.2.0/gems/thin_out_backups-0.0.6/lib/thin_out_backups.rb:64:in `initialize': uninitialized constant ThinOutBackups::Command::Bucket::Fixnum (NameError)

      raise "Invalid quota '#{quota}'" unless quota.is_a?(Fixnum) || quota =~ @@quota_format
                                                          ^^^^^^
	from /home/jash/.rvm/gems/ruby-3.2.0/gems/thin_out_backups-0.0.6/lib/thin_out_backups.rb:180:in `new'
	from /home/jash/.rvm/gems/ruby-3.2.0/gems/thin_out_backups-0.0.6/lib/thin_out_backups.rb:180:in `block in initialize'
	from /home/jash/.rvm/gems/ruby-3.2.0/gems/thin_out_backups-0.0.6/lib/thin_out_backups.rb:178:in `each'
	from /home/jash/.rvm/gems/ruby-3.2.0/gems/thin_out_backups-0.0.6/lib/thin_out_backups.rb:178:in `initialize'
	from /home/jash/.rvm/gems/ruby-3.2.0/gems/thin_out_backups-0.0.6/bin/thin_out_backups:177:in `new'
	from /home/jash/.rvm/gems/ruby-3.2.0/gems/thin_out_backups-0.0.6/bin/thin_out_backups:177:in `block in <top (required)>'
	from /home/jash/.rvm/gems/ruby-3.2.0/gems/thin_out_backups-0.0.6/bin/thin_out_backups:176:in `each'
	from /home/jash/.rvm/gems/ruby-3.2.0/gems/thin_out_backups-0.0.6/bin/thin_out_backups:176:in `<top (required)>'
	from /home/jash/.rvm/gems/ruby-3.2.0/bin/thin_out_backups:25:in `load'
	from /home/jash/.rvm/gems/ruby-3.2.0/bin/thin_out_backups:25:in `<main>'
	from /home/jash/.rvm/gems/ruby-3.2.0/bin/ruby_executable_hooks:22:in `eval'
	from /home/jash/.rvm/gems/ruby-3.2.0/bin/ruby_executable_hooks:22:in `<main>'
```